### PR TITLE
Add settings to enable JIT in PHP

### DIFF
--- a/prime-number/php/run-example.sh
+++ b/prime-number/php/run-example.sh
@@ -2,4 +2,4 @@
 
 . ../run-helper.sh
 
-start 'PHP' 'php np.php'
+start 'PHP' 'php -dmemory_limit=256M -dopcache.enable_cli=1 -dopcache.jit_buffer_size=32M np.php'


### PR DESCRIPTION
This reduces the execution time in PHP by 1/3.

Without JIT: 
```
Real time: 58.65 sec
Max RSS  : 160412 KiB
```

With JIT: 
```
Real time: 18.86 sec
Max RSS  : 163904 KiB
```