### PR TITLE
Improve the PHP code

### DIFF
--- a/prime-number/php/np.php
+++ b/prime-number/php/np.php
@@ -1,12 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 class PrimeNumber {
-
-   function __construct() {
-       $this->prime_numbers = [];
-   }
-
-   function is_prime_number($n) {
+    private array $prime_numbers = [];
+    private function is_prime_number(int $n): bool {
         foreach ($this->prime_numbers as $np) {
             if ($np * $np > $n)
                 return true;
@@ -16,7 +14,7 @@ class PrimeNumber {
         return true;
     }
 
-    function calc($upper_limit) {
+    public function calc(int $upper_limit): void {
 
         for ($n = 2; $n <= $upper_limit; $n++) {
             if ($this->is_prime_number($n))
@@ -26,14 +24,14 @@ class PrimeNumber {
         echo "Count: " . count($this->prime_numbers) . "\n";
     }
 
-    function show() {
+    public function show(): void {
         foreach ($this->prime_numbers as $pn)
             echo $pn . "\n";
     }
 
 }
 
-function parseArg() {
+function parseArg(): array {
 
     $opt = [
         "upper_limit" => 0,
@@ -69,8 +67,6 @@ function parseArg() {
 $args = parseArg();
 
 $pn = new PrimeNumber();
-$pn->calc($args["upper_limit"]);
+$pn->calc((int)$args["upper_limit"]);
 if ($args["show"])
     $pn->show();
-
-?>


### PR DESCRIPTION
Should be merged after #2.

The optimizer uses type informations, so adding types should result in slightly better execution time. Also, the code will be more robust and readable.

Using dynamic properties is slow, and even deprecated as of PHP 8.2. So changed to declare explicitly. This also improves robustness a bit as it aids static analysis in IDEs and editors.

Usually we don't use closing PHP tags outside of templating uses. This is because unintentionally added whitespaces after the closing tag are added to the output.

Before:
```
Real time: 18.86 sec
Max RSS  : 163904 KiB
```

After:
```
Real time: 17.53 sec
Max RSS  : 163780 KiB
```